### PR TITLE
Let rqw customize the terminate signal

### DIFF
--- a/rqw.go
+++ b/rqw.go
@@ -16,24 +16,26 @@ import (
 func main() {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	config := struct {
-		Addr     string        `flag:"redis,redis instance address"`
-		Name     string        `flag:"queue,queue name"`
-		Program  string        `flag:"worker,path to worker program"`
-		Thresh   int           `flag:"threshold,min queue size to spawn workers"`
-		Limit    int           `flag:"max,max number of workers"`
-		Delay    time.Duration `flag:"delay,delay between checks (min. 1s)"`
-		Grace    time.Duration `flag:"grace,grace period to keep last worker alive"`
-		KillWait time.Duration `flag:"wait,how much to wait for a worker to gracefully exit before killing it"`
+		Addr       string        `flag:"redis,redis instance address"`
+		Name       string        `flag:"queue,queue name"`
+		Program    string        `flag:"worker,path to worker program"`
+		Thresh     int           `flag:"threshold,min queue size to spawn workers"`
+		Limit      int           `flag:"max,max number of workers"`
+		TermSignal int           `flag:"signal,number to send to terminate the worker"`
+		Delay      time.Duration `flag:"delay,delay between checks (min. 1s)"`
+		Grace      time.Duration `flag:"grace,grace period to keep last worker alive"`
+		KillWait   time.Duration `flag:"wait,how much to wait for a worker to gracefully exit before killing it"`
 
 		Debug bool `flag:"d,prefix output with source code addresses"`
 	}{
-		Addr:     "localhost:6379",
-		Name:     "",
-		Program:  "",
-		Limit:    10,
-		Delay:    15 * time.Second,
-		Grace:    10 * time.Minute,
-		KillWait: time.Second,
+		Addr:       "localhost:6379",
+		Name:       "",
+		Program:    "",
+		Limit:      10,
+		TermSignal: int(syscall.SIGTERM),
+		Delay:      15 * time.Second,
+		Grace:      10 * time.Minute,
+		KillWait:   time.Second,
 	}
 	autoflags.Define(&config)
 	flag.Parse()
@@ -58,6 +60,7 @@ func main() {
 		troop = rqw.WithGracePeriod(troop, config.Grace)
 	}
 	troop = rqw.WithKillDelay(troop, config.KillWait)
+	troop = rqw.WithTermSignal(troop, syscall.Signal(config.TermSignal))
 	go func() {
 		sigch := make(chan os.Signal, 1)
 		signal.Notify(sigch, syscall.SIGUSR1)


### PR DESCRIPTION
The default behavior of rqw is send SIGTERM, and then SIGKILL signals.
Although in Python, it's easier to catch SIGINT (2), because it's
automatically converted to a KeyboardInterput exception, and you don't
need to set up a specific signal handler to process it.

This commit adds an option "-signal" that allows to override the default
SIGTERM (15) with a different signal number.